### PR TITLE
Made project compilable

### DIFF
--- a/JGLayoutDotSyntax/JGLayoutParameter.h
+++ b/JGLayoutDotSyntax/JGLayoutParameter.h
@@ -10,6 +10,13 @@
 
 @interface JGLayoutParameter : NSObject <JGLayoutConstruction>
 
+enum JGLayoutPriority{
+    JGLayoutPriorityRequired = (int)UILayoutPriorityRequired,
+    JGLayoutPriorityDefaultHigh = (int)UILayoutPriorityDefaultHigh,
+    JGLayoutPriorityDefaultLow = (int)UILayoutPriorityDefaultLow,
+    JGLayoutPriorityFittingSizeLevel = (int)UILayoutPriorityFittingSizeLevel
+};
+
 @property (nonatomic, readonly) NSLayoutAttribute attribute;
 @property (nonatomic, readonly) NSLayoutRelation relation;
 @property (nonatomic, readonly) id object;

--- a/JGLayoutDotSyntax/UIView+Layout.m
+++ b/JGLayoutDotSyntax/UIView+Layout.m
@@ -165,7 +165,7 @@
     else constraint = [NSLayoutConstraint constraintWithItem:self attribute:attribute relatedBy:NSLayoutRelationEqual toItem:self attribute:attribute multiplier:0 constant:parameter.currentConstant];
     
     // Sets priority, if specified
-    if (parameter.priority) constraint.priority = parameter.priority;
+    if (parameter.priority) constraint.priority = (float)parameter.priority;    //Added implied float conversion for clarity
     
     // Adds constraint
     [receiver addConstraint:constraint];

--- a/LayoutDotSyntaxExample/LayoutDotSyntaxExample/JGViewController.m
+++ b/LayoutDotSyntaxExample/LayoutDotSyntaxExample/JGViewController.m
@@ -76,7 +76,7 @@
     
     redView.width = @(size);
     redView.height = @(size);
-    redView.centerX = self.view.centerX[(int)UILayoutPriorityDefaultHigh];
+    redView.centerX = self.view.centerX[JGLayoutPriorityDefaultHigh];
     redView.centerY = self.view.centerY;
     redView.left = [[blueView.right add:@(10)] withRelation:NSLayoutRelationGreaterThanOrEqual];
     

--- a/LayoutDotSyntaxExample/LayoutDotSyntaxExample/JGViewController.m
+++ b/LayoutDotSyntaxExample/LayoutDotSyntaxExample/JGViewController.m
@@ -76,7 +76,7 @@
     
     redView.width = @(size);
     redView.height = @(size);
-    redView.centerX = self.view.centerX[UILayoutPriorityDefaultHigh];
+    redView.centerX = self.view.centerX[(int)UILayoutPriorityDefaultHigh];
     redView.centerY = self.view.centerY;
     redView.left = [[blueView.right add:@(10)] withRelation:NSLayoutRelationGreaterThanOrEqual];
     

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The add method takes a CGFloat as an input argument and sets it as the NSLayoutC
 Additionally, JGLayoutDotSyntax allows priority to be specified. In favor of concision, a slightly irregular syntax is used. After a JGLayoutParameter, square backets can be used to specifiy priority of a constraint, if needed. For example, we can lower the priority of centering our subview:
 
 ```objc
-subview.centerX = self.view.centerX[UILayoutPriorityDefaultLow];
+subview.centerX = self.view.centerX[(int)UILayoutPriorityDefaultLow];
 ```
 
 The argument between the brackets should be a UILayoutPriority, which is represented by a positive integer, less than or equal to 1000 (as specified in Apple's NSLayoutConstraint documentation).
@@ -93,7 +93,7 @@ blueView.width = @190;
 
 redView.width = @(size);
 redView.height = @(size);
-redView.centerX = self.view.centerX[UILayoutPriorityDefaultHigh];
+redView.centerX = self.view.centerX[(int)UILayoutPriorityDefaultHigh];
 redView.centerY = self.view.centerY;
 redView.left = [[blueView.right add:@(10)] withRelation:NSLayoutRelationGreaterThanOrEqual];
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The add method takes a CGFloat as an input argument and sets it as the NSLayoutC
 Additionally, JGLayoutDotSyntax allows priority to be specified. In favor of concision, a slightly irregular syntax is used. After a JGLayoutParameter, square backets can be used to specifiy priority of a constraint, if needed. For example, we can lower the priority of centering our subview:
 
 ```objc
-subview.centerX = self.view.centerX[(int)UILayoutPriorityDefaultLow];
+subview.centerX = self.view.centerX[JGLayoutPriorityDefaultHigh];
 ```
 
 The argument between the brackets should be a UILayoutPriority, which is represented by a positive integer, less than or equal to 1000 (as specified in Apple's NSLayoutConstraint documentation).
@@ -93,7 +93,7 @@ blueView.width = @190;
 
 redView.width = @(size);
 redView.height = @(size);
-redView.centerX = self.view.centerX[(int)UILayoutPriorityDefaultHigh];
+redView.centerX = self.view.centerX[JGLayoutPriorityDefaultHigh];
 redView.centerY = self.view.centerY;
 redView.left = [[blueView.right add:@(10)] withRelation:NSLayoutRelationGreaterThanOrEqual];
 


### PR DESCRIPTION
Apparently, a recent change caused UILayoutPriority to become a float type, even though the actual enumerated values are still integers. Due to this type change, subscript property keying using UILayoutPriority fails. To fix this issue, I created an enumeration similar to the one in the Swift version of the project that casts the Priority values to integers. This fix allow the code to compile, and improves consistency between the two versions of the project.
